### PR TITLE
Map ODRL party collections to CIDOC-CRM groups

### DIFF
--- a/src/ontology/cacao-edit.owl
+++ b/src/ontology/cacao-edit.owl
@@ -1244,6 +1244,10 @@ SubClassOf(<http://www.w3.org/ns/odrl/2/Asset> <http://www.cidoc-crm.org/cidoc-c
 
 SubClassOf(<http://www.w3.org/ns/odrl/2/Party> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>)
 
+# Class: <http://www.w3.org/ns/odrl/2/PartyCollection> (Party Collection)
+
+SubClassOf(<http://www.w3.org/ns/odrl/2/PartyCollection> <http://www.cidoc-crm.org/cidoc-crm/E74_Group>)
+
 # Class: <http://www.w3.org/ns/prov#Organization> (Organization)
 
 SubClassOf(<http://www.w3.org/ns/prov#Organization> <http://www.cidoc-crm.org/cidoc-crm/E74_Group>)


### PR DESCRIPTION
Adds the missing ontology axiom mapping `odrl:PartyCollection` to `crm:E74_Group`, consistent with the existing `odrl:Party` → `crm:E39_Actor` mapping and the paper's mapping table.

Validation: `git diff --check`. Generated release artifacts are left to the repository's ODK release workflow.